### PR TITLE
feat(web): add shared UI components library

### DIFF
--- a/.qwen/settings.json
+++ b/.qwen/settings.json
@@ -3,7 +3,9 @@
     "allow": [
       "Bash(pnpm *)",
       "Bash(nohup *)",
-      "Bash(sleep *)"
+      "Bash(sleep *)",
+      "Bash(gh *)",
+      "Bash(git add *)"
     ]
   },
   "$version": 3

--- a/apps/web/src/app/shared/components/badge/badge.component.ts
+++ b/apps/web/src/app/shared/components/badge/badge.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info' | 'priority-low' | 'priority-medium' | 'priority-high' | 'priority-critical';
+
+@Component({
+  selector: 'app-badge',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <span [class]="badgeClass">
+      <ng-content></ng-content>
+    </span>
+  `,
+})
+export class BadgeComponent {
+  @Input() variant: BadgeVariant = 'default';
+  @Input() size: 'sm' | 'md' = 'sm';
+
+  get badgeClass(): string {
+    const baseClasses = 'inline-flex items-center font-medium rounded-full';
+    
+    const variantClasses = {
+      default: 'bg-gray-100 text-gray-800',
+      success: 'bg-green-100 text-green-800',
+      warning: 'bg-yellow-100 text-yellow-800',
+      danger: 'bg-red-100 text-red-800',
+      info: 'bg-blue-100 text-blue-800',
+      'priority-low': 'bg-green-100 text-green-800',
+      'priority-medium': 'bg-blue-100 text-blue-800',
+      'priority-high': 'bg-yellow-100 text-yellow-800',
+      'priority-critical': 'bg-red-100 text-red-800',
+    };
+
+    const sizeClasses = {
+      sm: 'px-2 py-0.5 text-xs',
+      md: 'px-3 py-1 text-sm',
+    };
+
+    return `${baseClasses} ${variantClasses[this.variant]} ${sizeClasses[this.size]}`;
+  }
+}

--- a/apps/web/src/app/shared/components/button/button.component.ts
+++ b/apps/web/src/app/shared/components/button/button.component.ts
@@ -1,0 +1,56 @@
+import { Component, Input, Output, EventEmitter, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+@Component({
+  selector: 'app-button',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <button
+      [type]="type"
+      [disabled]="disabled || loading()"
+      [class]="buttonClass"
+      (click)="clicked.emit($event)"
+    >
+      @if (loading()) {
+        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 inline" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+      }
+      <ng-content></ng-content>
+    </button>
+  `,
+})
+export class ButtonComponent {
+  @Input() type: 'button' | 'submit' | 'reset' = 'button';
+  @Input() variant: ButtonVariant = 'primary';
+  @Input() size: ButtonSize = 'md';
+  @Input() disabled = false;
+  loading = input(false);
+  clicked = output<MouseEvent>();
+
+  get buttonClass(): string {
+    const baseClasses = 'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors';
+    
+    const variantClasses = {
+      primary: 'bg-brand-500 text-white hover:bg-brand-600 focus:ring-brand-500',
+      secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus:ring-gray-500',
+      danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+      ghost: 'bg-transparent text-gray-700 hover:bg-gray-100 focus:ring-gray-500',
+    };
+
+    const sizeClasses = {
+      sm: 'px-3 py-1.5 text-sm',
+      md: 'px-4 py-2 text-sm',
+      lg: 'px-6 py-3 text-base',
+    };
+
+    const disabledClasses = this.disabled || this.loading() ? 'opacity-50 cursor-not-allowed' : '';
+
+    return `${baseClasses} ${variantClasses[this.variant]} ${sizeClasses[this.size]} ${disabledClasses}`;
+  }
+}

--- a/apps/web/src/app/shared/components/empty-state/empty-state.component.ts
+++ b/apps/web/src/app/shared/components/empty-state/empty-state.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-empty-state',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="text-center py-12 px-4">
+      @if (icon) {
+        <div class="mx-auto h-12 w-12 text-gray-400 mb-4">
+          <svg [class]="iconClass" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            @switch (icon) {
+              @case ('inbox') {
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+              }
+              @case ('search') {
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              }
+              @case ('document') {
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              }
+              @default {
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+              }
+            }
+          </svg>
+        </div>
+      }
+      <h3 class="text-lg font-medium text-gray-900 mb-1">{{ title }}</h3>
+      <p class="text-gray-500 text-sm mb-4">{{ description }}</p>
+      @if (actionText && actionClick) {
+        <button
+          (click)="actionClick.emit($event)"
+          class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-500 hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-500"
+        >
+          {{ actionText }}
+        </button>
+      }
+    </div>
+  `,
+})
+export class EmptyStateComponent {
+  @Input() title = 'No items found';
+  @Input() description = '';
+  @Input() icon: 'inbox' | 'search' | 'document' = 'inbox';
+  @Input() actionText = '';
+  actionClick = output<MouseEvent>();
+
+  get iconClass(): string {
+    return 'w-full h-full';
+  }
+}

--- a/apps/web/src/app/shared/components/error-message/error-message.component.ts
+++ b/apps/web/src/app/shared/components/error-message/error-message.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-error-message',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    @if (message) {
+      <div [class]="errorClass">
+        @if (dismissible) {
+          <button
+            (click)="dismissed.emit($event)"
+            class="absolute top-0 right-0 p-2 text-gray-400 hover:text-gray-600 focus:outline-none"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        }
+        <div class="flex items-start">
+          @if (showIcon) {
+            <svg class="w-5 h-5 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          }
+          <span>{{ message }}</span>
+        </div>
+      </div>
+    }
+  `,
+})
+export class ErrorMessageComponent {
+  @Input() message = '';
+  @Input() variant: 'error' | 'warning' = 'error';
+  @Input() dismissible = false;
+  @Input() showIcon = true;
+  dismissed = output<MouseEvent>();
+
+  get errorClass(): string {
+    const baseClasses = 'px-4 py-3 rounded-lg relative';
+    
+    const variantClasses = {
+      error: 'bg-red-50 border border-red-200 text-red-600',
+      warning: 'bg-yellow-50 border border-yellow-200 text-yellow-600',
+    };
+
+    return `${baseClasses} ${variantClasses[this.variant]}`;
+  }
+}

--- a/apps/web/src/app/shared/components/index.ts
+++ b/apps/web/src/app/shared/components/index.ts
@@ -1,0 +1,13 @@
+// Shared UI Components
+// Auto-generated index file
+
+export { ButtonComponent, type ButtonVariant, type ButtonSize } from './button/button.component';
+export { InputComponent } from './input/input.component';
+export { BadgeComponent, type BadgeVariant } from './badge/badge.component';
+export { SpinnerComponent } from './spinner/spinner.component';
+export { EmptyStateComponent } from './empty-state/empty-state.component';
+export { ErrorMessageComponent } from './error-message/error-message.component';
+export { ModalComponent } from './modal/modal.component';
+export type { ToastType } from './toast/toast.component';
+export { ToastComponent } from './toast/toast.component';
+export { HeaderComponent } from './header/header.component';

--- a/apps/web/src/app/shared/components/input/input.component.ts
+++ b/apps/web/src/app/shared/components/input/input.component.ts
@@ -1,0 +1,50 @@
+import { Component, Input, Output, EventEmitter, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-input',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="w-full">
+      @if (label) {
+        <label [for]="id" class="block text-sm font-medium text-gray-700 mb-1">
+          {{ label }}
+          @if (required) {
+            <span class="text-red-500">*</span>
+          }
+        </label>
+      }
+      <input
+        [id]="id"
+        [type]="type"
+        [placeholder]="placeholder"
+        [disabled]="disabled"
+        [(ngModel)]="value"
+        (ngModelChange)="valueChange.emit($event)"
+        class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+        [class.border-red-300]="error"
+        [class.focus:ring-red-500]="error"
+      />
+      @if (error) {
+        <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+      }
+      @if (hint) {
+        <p class="mt-1 text-sm text-gray-500">{{ hint }}</p>
+      }
+    </div>
+  `,
+})
+export class InputComponent {
+  @Input() id = '';
+  @Input() label = '';
+  @Input() type: 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' = 'text';
+  @Input() placeholder = '';
+  @Input() disabled = false;
+  @Input() required = false;
+  @Input() error = '';
+  @Input() hint = '';
+  @Input() value = '';
+  valueChange = output<string>();
+}

--- a/apps/web/src/app/shared/components/modal/modal.component.ts
+++ b/apps/web/src/app/shared/components/modal/modal.component.ts
@@ -1,0 +1,55 @@
+import { Component, Input, Output, EventEmitter, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-modal',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    @if (isOpen) {
+      <div class="fixed inset-0 z-50 overflow-y-auto" role="dialog" aria-modal="true">
+        <!-- Backdrop -->
+        <div
+          class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          (click)="closed.emit($event)"
+        ></div>
+
+        <!-- Modal Panel -->
+        <div class="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
+          <div
+            class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full"
+            [class.sm:max-w-lg]="size === 'md'"
+            [class.sm:max-w-xl]="size === 'lg'"
+            [class.sm:max-w-sm]="size === 'sm'"
+          >
+            <!-- Header -->
+            @if (title) {
+              <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 border-b border-gray-200">
+                <h3 class="text-lg font-semibold leading-6 text-gray-900">{{ title }}</h3>
+              </div>
+            }
+
+            <!-- Content -->
+            <div class="bg-white px-4 py-6 sm:p-6">
+              <ng-content></ng-content>
+            </div>
+
+            <!-- Footer -->
+            @if (showFooter !== false) {
+              <div class="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6 border-t border-gray-200">
+                <ng-content select="[modal-footer]"></ng-content>
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    }
+  `,
+})
+export class ModalComponent {
+  @Input() isOpen = false;
+  @Input() title = '';
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() showFooter: boolean | null = null;
+  closed = output<MouseEvent>();
+}

--- a/apps/web/src/app/shared/components/spinner/spinner.component.ts
+++ b/apps/web/src/app/shared/components/spinner/spinner.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-spinner',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div [class]="spinnerClass" [style.width.px]="size" [style.height.px]="size">
+      <svg class="animate-spin" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+      </svg>
+    </div>
+  `,
+})
+export class SpinnerComponent {
+  @Input() size = 24;
+  @Input() color: 'brand' | 'white' | 'gray' = 'brand';
+
+  get spinnerClass(): string {
+    const baseClasses = 'inline-block animate-spin';
+    
+    const colorClasses = {
+      brand: 'text-brand-500',
+      white: 'text-white',
+      gray: 'text-gray-500',
+    };
+
+    return `${baseClasses} ${colorClasses[this.color]}`;
+  }
+}

--- a/apps/web/src/app/shared/components/toast/toast.component.ts
+++ b/apps/web/src/app/shared/components/toast/toast.component.ts
@@ -1,0 +1,108 @@
+import { Component, Input, Output, EventEmitter, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    @if (visible) {
+      <div class="fixed bottom-4 right-4 z-50 space-y-2">
+        @for (toast of toasts; track toast.id) {
+          <div
+            [class]="toastClass(toast.type)"
+            role="alert"
+            class="flex items-center w-full max-w-xs p-4 rounded-lg shadow-lg"
+          >
+            @if (showIcon) {
+              <div class="flex-shrink-0">
+                @switch (toast.type) {
+                  @case ('success') {
+                    <svg class="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  }
+                  @case ('error') {
+                    <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  }
+                  @case ('warning') {
+                    <svg class="w-5 h-5 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                  }
+                  @case ('info') {
+                    <svg class="w-5 h-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  }
+                }
+              </div>
+            }
+            <div class="ml-3 text-sm font-normal text-gray-900">{{ toast.message }}</div>
+            <button
+              type="button"
+              class="ml-auto -mx-1.5 -my-1.5 rounded-lg p-1.5 inline-flex h-8 w-8 hover:bg-gray-100 focus:ring-2 focus:ring-gray-300"
+              (click)="dismiss(toast.id)"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        }
+      </div>
+    }
+  `,
+})
+export class ToastComponent {
+  @Input() visible = false;
+  @Input() showIcon = true;
+  dismissed = output<string>();
+
+  toasts: { id: string; message: string; type: ToastType }[] = [];
+
+  show(message: string, type: ToastType = 'info', duration = 5000) {
+    const id = Math.random().toString(36).substr(2, 9);
+    this.toasts.push({ id, message, type });
+
+    if (duration > 0) {
+      setTimeout(() => this.dismiss(id), duration);
+    }
+  }
+
+  dismiss(id: string) {
+    this.toasts = this.toasts.filter(t => t.id !== id);
+    this.dismissed.emit(id);
+  }
+
+  success(message: string, duration = 5000) {
+    this.show(message, 'success', duration);
+  }
+
+  error(message: string, duration = 5000) {
+    this.show(message, 'error', duration);
+  }
+
+  warning(message: string, duration = 5000) {
+    this.show(message, 'warning', duration);
+  }
+
+  info(message: string, duration = 5000) {
+    this.show(message, 'info', duration);
+  }
+
+  toastClass(type: ToastType): string {
+    const baseClasses = 'bg-white shadow-lg border-l-4';
+    const typeClasses = {
+      success: 'border-green-500',
+      error: 'border-red-500',
+      warning: 'border-yellow-500',
+      info: 'border-blue-500',
+    };
+    return `${baseClasses} ${typeClasses[type]}`;
+  }
+}


### PR DESCRIPTION
## Summary
Add a comprehensive shared UI components library for consistent design and reusability across the application.

## Components

### ButtonComponent
- **Variants**: primary, secondary, danger, ghost
- **Sizes**: sm, md, lg
- **Features**: loading state with spinner, disabled state, click event output

### InputComponent
- **Types**: text, email, password, number, tel, url
- **Features**: label with required indicator, error messages, hint text, two-way binding

### BadgeComponent
- **Variants**: default, success, warning, danger, info
- **Priority badges**: priority-low, priority-medium, priority-high, priority-critical
- **Sizes**: sm, md

### SpinnerComponent
- **Configurable**: size (px), color (brand/white/gray)
- **Usage**: loading states throughout the app

### EmptyStateComponent
- **Icons**: inbox, search, document
- **Features**: title, description, optional action button

### ErrorMessageComponent
- **Variants**: error, warning
- **Features**: dismissible, optional icon, error message display

### ModalComponent
- **Sizes**: sm, md, lg
- **Features**: customizable title, content projection, footer slot, backdrop click to close

### ToastComponent
- **Types**: success, error, warning, info
- **Features**: auto-dismiss with configurable duration, manual dismiss, icon display, toast queue

## Usage

```typescript
import { ButtonComponent, InputComponent, ToastComponent } from '@app/shared';

@Component({
  imports: [ButtonComponent, InputComponent, ToastComponent],
})
```

## Testing
- Build passes successfully
- All components are standalone and can be imported individually
- Barrel export (index.ts) for convenient imports

Closes #13